### PR TITLE
Revert "set memory parameters for 2GB devices"

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -15,5 +15,3 @@
 include device/sony/rhine/BoardConfig.mk
 
 TARGET_BOOTLOADER_BOARD_NAME := D5503
-
-BOARD_KERNEL_CMDLINE += coherent_pool=8M mem=1920M


### PR DESCRIPTION
This reverts commit a80443ed5b42b655e8bfcecebcc55062ac551bac.
Already defined in rhine boardconfig