### PR TITLE
amami: use specific idProduct for usb paths

### DIFF
--- a/aosp_d5503.mk
+++ b/aosp_d5503.mk
@@ -42,5 +42,5 @@ PRODUCT_AAPT_PREBUILT_DPI := xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xhdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sf.lcd_density=320
-
+    ro.sf.lcd_density=320 \
+    ro.usb.pid_suffix=1A7


### PR DESCRIPTION
from 14.4.A.0.157

Signed-off-by: David Viteri <davidteri91@gmail.com>